### PR TITLE
Add plist key for high-res window chrome on OS X

### DIFF
--- a/Code/ClientGame/platforms/mac/ClientGameInfo.plist
+++ b/Code/ClientGame/platforms/mac/ClientGameInfo.plist
@@ -18,5 +18,7 @@
 	<string>1.0</string>
 	<key>CFBundleIconFile</key>
 	<string>angel</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>

--- a/Code/IntroGame/platforms/mac/IntroGameInfo.plist
+++ b/Code/IntroGame/platforms/mac/IntroGameInfo.plist
@@ -18,5 +18,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Hey Shane, this is a start for the retina Mac stuff. I couldn't find any contributing guidelines for the project, so I hope this OK. This'll make the window support retina stuff and make the titlebar automatically retina-res.

Here's before:

![before](https://f.cloud.github.com/assets/6129/365507/a544f48c-a24a-11e2-9a92-5994076ff74e.png)

And after:

![after](https://f.cloud.github.com/assets/6129/365508/ab19016e-a24a-11e2-80e7-143f34878c2d.png)
