### PR TITLE
Fixing build issues with Visual Studio 2012

### DIFF
--- a/Code/Angel/Libraries/FTGL/win32_vcpp/ftgl_static_lib/ftgl_static_lib.vcxproj
+++ b/Code/Angel/Libraries/FTGL/win32_vcpp/ftgl_static_lib/ftgl_static_lib.vcxproj
@@ -140,7 +140,7 @@
       <PreprocessorDefinitions>_DEBUG;WIN32;_LIB;FTGL_LIBRARY_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeaderOutputFile>.\Debug_ST/ftgl_static_lib.pch</PrecompiledHeaderOutputFile>
       <AssemblerListingLocation>.\Debug_ST/</AssemblerListingLocation>
       <ObjectFileName>.\Debug_ST/</ObjectFileName>

--- a/Code/ClientGame/ClientGame.vcxproj
+++ b/Code/ClientGame/ClientGame.vcxproj
@@ -24,6 +24,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+	<LocalDebuggerEnvironment>PATH=%PATH%;$(ProjectDir)</LocalDebuggerEnvironment>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/Code/IntroGame/IntroGame.vcxproj
+++ b/Code/IntroGame/IntroGame.vcxproj
@@ -24,6 +24,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
+	<LocalDebuggerEnvironment>PATH=%PATH%;$(ProjectDir)</LocalDebuggerEnvironment>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
- Runtime library of ftgl for debug should be the dll
- Visual Studio 2012, unlike 2010, doesn't add the project root to the path during debug builds. Adding them into the configuration.

Refer to this thread for specifics:
https://groups.google.com/forum/#!topic/angel-engine/rLI-sAB_Dso
