### PR TITLE
Add Debian to *nix prereqs

### DIFF
--- a/Code/Angel/nix-prereqs.sh
+++ b/Code/Angel/nix-prereqs.sh
@@ -18,7 +18,7 @@ elif [ -f /etc/lsb-release ] ; then
 		DIST='Ubuntu'
 	fi
 elif [ -f /etc/debian_version ] ; then
-	DIST='Ubuntu'
+	DIST='Debian'
 elif [ "`uname`" == 'Darwin' ] ; then
 	DIST='Darwin'
 fi
@@ -30,8 +30,13 @@ if   [ "$DIST" == 'Fedora' ] ; then
 elif [ "$DIST" == 'Ubuntu' ] ; then
 	apt-get -y install build-essential cmake swig libglu1-mesa-dev\
 		libreadline-dev libdevil-dev libxrandr-dev libfreetype6-dev\
-		joystick libopenal-dev libvorbis-dev libpng12-dev ncurses-dev \
+		joystick libopenal-dev libvorbis-dev libpng12-dev ncurses-dev\
 		libxi-dev
+elif [ "$DIST" == 'Debian' ] ; then
+	apt-get -y install build-essential cmake swig libglu1-mesa-dev\
+		libreadline-dev libdevil-dev libxrandr-dev libfreetype6-dev\
+		joystick libopenal-dev libvorbis-dev libpng12-dev ncurses-dev\
+		libxi-dev xorg-dev libglu-mesa-dev
 elif [ "$DIST" == 'Darwin' ] ; then
 	if [ "`which make`" == "" ] ; then
 		echo "The Xcode command line tools are not installed."
@@ -68,6 +73,6 @@ elif [ "$DIST" == 'Darwin' ] ; then
 	fi
 else
 	echo "This is not a recognized Linux or UNIX distribution."
-	echo "Currently we support Fedora, Ubuntu, and OS X."
+	echo "Currently we support Fedora, Ubuntu, Debian, and OS X."
 fi
 

--- a/Code/Angel/nix-prereqs.sh
+++ b/Code/Angel/nix-prereqs.sh
@@ -17,6 +17,8 @@ elif [ -f /etc/lsb-release ] ; then
 	if [ $DINFO == 'Ubuntu' ] ; then
 		DIST='Ubuntu'
 	fi
+elif [ -f /etc/debian_version ] ; then
+	DIST='Ubuntu'
 elif [ "`uname`" == 'Darwin' ] ; then
 	DIST='Darwin'
 fi

--- a/Code/Angel/nix-prereqs.sh
+++ b/Code/Angel/nix-prereqs.sh
@@ -35,8 +35,8 @@ elif [ "$DIST" == 'Ubuntu' ] ; then
 elif [ "$DIST" == 'Debian' ] ; then
 	apt-get -y install build-essential cmake swig libglu1-mesa-dev\
 		libreadline-dev libdevil-dev libxrandr-dev libfreetype6-dev\
-		joystick libopenal-dev libvorbis-dev libpng12-dev ncurses-dev\
-		libxi-dev xorg-dev libglu-mesa-dev
+		joystick libopenal-dev libvorbis-dev libpng12-dev\
+		libncurses5-dev libxi-dev xorg-dev libglu1-mesa-dev
 elif [ "$DIST" == 'Darwin' ] ; then
 	if [ "`which make`" == "" ] ; then
 		echo "The Xcode command line tools are not installed."

--- a/README.markdown
+++ b/README.markdown
@@ -102,7 +102,7 @@ there are some prerequisites for each platform, still.
       into account when doing any calculations about pixel distances.
 
 ### Linux ###
-* Angel's tested on the latest releases of Ubuntu and Fedora. It should work
+* Angel's tested on the latest releases of Debian, Ubuntu, and Fedora. It should work
   on other recent distributions as well so long as all the dependencies are
   installed. 
 * If you're on one of those supported distributions, navigate to `Code/Angel` 


### PR DESCRIPTION
Debian uses apt, and can successfully install dependencies running the script as dist=Ubuntu. [test output running Debian Jessie](https://gist.github.com/humanoidanalog/7784653)
