### PR TITLE
Minor IntroGame Bug Fix (Pathfinding Screen).

### DIFF
--- a/Code/IntroGame/DemoScreens/DemoScreenPathfinding.cpp
+++ b/Code/IntroGame/DemoScreens/DemoScreenPathfinding.cpp
@@ -109,7 +109,7 @@ void DemoScreenPathfinding::Update(float dt)
 		theSpatialGraph.EnableDrawGraph(false);
 	}
 	
-	MazeFinder* mf = (MazeFinder*)Actor::GetNamed("MazeFinder");
+	MazeFinder* mf = (MazeFinder*)Actor::GetNamed("RedRunner");
 	if (mf != NULL)
 	{
 		if ((theController.IsConnected() && theController.IsYButtonDown()) || theInput.IsKeyDown('y'))


### PR DESCRIPTION
This is a simple fix to a bug that caused the Pathfinding demo screen to update the wrong object. It happens when one skips the Pathfinding demo screen and then returns to it, the pointer we call the functions Update() and Render() are different, causing the Planned path to never be drawn.
