### PR TITLE
Fixing LoadSpriteFrame documentation

### DIFF
--- a/Code/Angel/Actors/Actor.h
+++ b/Code/Angel/Actors/Actor.h
@@ -333,8 +333,8 @@ public:
 
 	/**
 	 * A convenience function for loading up a directory of image files as an
-	 *  animation. We expect the name of the first image to end in _###, where
-	 *  ### represents a number. The number of digits you put at the end 
+	 *  animation. We expect the name of the first image to end in _#, where
+	 *  # represents a number. The number of digits you put at the end 
 	 *  doesn't matter, but we are internally limited to 64 frames. If you 
 	 *  want more, just change MAX_SPRITE_FRAMES in Actor.h. 
 	 * 

--- a/Code/Angel/Actors/Actor.h
+++ b/Code/Angel/Actors/Actor.h
@@ -333,8 +333,8 @@ public:
 
 	/**
 	 * A convenience function for loading up a directory of image files as an
-	 *  animation. We expect the name of the first image to end in _#, where
-	 *  # represents a number. The number of digits you put at the end 
+	 *  animation. We expect the name of the first image to end in _#,
+	 *  where # represents a number. The number of digits you put at the end 
 	 *  doesn't matter, but we are internally limited to 64 frames. If you 
 	 *  want more, just change MAX_SPRITE_FRAMES in Actor.h. 
 	 * 


### PR DESCRIPTION
Fixing the documentation for Actor::LoadSpriteFrames() function. The # character is meaningful when it is the first in a line, what caused doxygen to interpret it; see image.

![doxy](https://f.cloud.github.com/assets/2046959/2122474/3eeb46a2-9211-11e3-9e29-16ee2380a40d.png)

Since the number of ### didn't matter, I replaced it with a single one (as we were already over col 72), and moved 'where' to the line below, what should fix the problem.
